### PR TITLE
Add Swift Package Manager Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
-
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+
+let package = Package(
+    name: "EstimoteProximitySDK",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        .library(
+            name: "EstimoteProximitySDK",
+            targets: [
+                "EstimoteProximitySDK"
+            ]
+        )
+    ],
+    targets: [
+        .binaryTarget(
+            name: "EstimoteProximitySDK",
+            path: "./EstimoteProximitySDK/EstimoteProximitySDK.xcframework"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Below there's a presentation of two zones:
 
 Starting with [version 1.2.0](https://github.com/Estimote/iOS-Proximity-SDK/releases/tag/v1.2.0) Proximity SDK supports Swift 4.2.
 
+### Swift Package Manager 
+
+Follow the article about [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) using the following repository URL: `https://github.com/Estimote/iOS-Proximity-SDK`.
+
 ### CocoaPods 
 [CocoaPods](https://cocoapods.org/) is an easy way to add external libraries. To use it to fetch Proximity SDK:
 1. Add `pod 'EstimoteProximitySDK'` to your Podfile


### PR DESCRIPTION
You can import it into your project or add it to your Swift Package by following the article about [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app) using the following repository URL: `https://github.com/Estimote/iOS-Proximity-SDK`. 

You will need to tag a new release to enable developers to start importing the SDK using the Swift Package Manager.